### PR TITLE
Stop warning when installing on npm >3

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
   },
   "main": "dist/index.js",
   "engines": {
-    "npm": "^3.0.0"
+    "npm": ">=3.0.0"
   }
 }


### PR DESCRIPTION
npm 3 is [pretty old](https://github.com/npm/cli/releases/tag/v4.0.0), and this warning is annoying:
<img width="469" alt="image" src="https://user-images.githubusercontent.com/9437625/155413905-b4cb6c76-6d1d-40dd-95c8-0ae1f207e854.png">

Some of the dev dependencies here have that same engine requirement, but realistically I don't think we care?