### PR TITLE
Remove npm requirement from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,5 @@
     "babel-runtime": "^6.26.0",
     "lottie-web": "^5.1.3"
   },
-  "main": "dist/index.js",
-  "engines": {
-    "npm": ">=3.0.0"
-  }
+  "main": "dist/index.js"
 }


### PR DESCRIPTION
A continuation of #1.

This is causing headaches for us downstream. Using a higher npm version shouldn't have an impact on the functionality of the package.