### PR TITLE
Allow React 17 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "standard-version": "^4.4.0"
   },
   "peerDependencies": {
-    "react": "^0.14.7 || ^15.0.0 || ^16.0.0"
+    "react": "^0.14.7 || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",


### PR DESCRIPTION
Should fix errors when running commands like `npm audit fix` downstream when using React 17.